### PR TITLE
Fix NFTContractSet event for NFTMulticlassBiddableAuction

### DIFF
--- a/ImagesNFTv2.sol
+++ b/ImagesNFTv2.sol
@@ -1127,7 +1127,7 @@ contract NFTMulticlassBiddableAuction is ActivatedByOwner {
 
     function setNFTContract(address _nftContract) public onlyOwner
     {
-        emit NFTContractSet(nft_contract, _nftContract);
+        emit NFTContractSet(_nftContract, nft_contract);
 
         nft_contract = _nftContract;
     }


### PR DESCRIPTION
The order of the parameters was swapped.

![image](https://user-images.githubusercontent.com/46317127/154407914-4a4ae0f7-6726-4584-9923-50496e6c99ce.png)
