### PR TITLE
Migration + BidOnNFT mod + others

### DIFF
--- a/ImagesNFTv2.sol
+++ b/ImagesNFTv2.sol
@@ -1320,9 +1320,13 @@ contract NFTMulticlassBiddableAuction is ActivatedByOwner {
     {
         require(msg.sender == revenue, "This action requires revenue permission");
 
-        emit RevenueWithdrawal(address(this).balance);
+        uint256 toPay = revenue_amount;
 
-        revenue.transfer(revenue_amount);
+        revenue_amount = 0;
+
+        revenue.transfer(toPay);
+
+        emit RevenueWithdrawal(toPay);
     }
 
     function toString(uint256 value) internal pure returns (string memory) {

--- a/ImagesNFTv2.sol
+++ b/ImagesNFTv2.sol
@@ -1285,7 +1285,7 @@ contract NFTMulticlassBiddableAuction is ActivatedByOwner {
     {
         auctions[_classID].winner          = owner();
         auctions[_classID].highest_bid     = 0;
-        auctions[_classID].start_timestamp = block.timestamp;
+        auctions[_classID].start_timestamp = block.timestamp + 600;
 
         emit NewRound(_classID, block.timestamp, auctions[_classID].start_timestamp + auctions[_classID].duration);
     }


### PR DESCRIPTION
**Comments on Migration:** 
`migrationMint `function allow an admin to mint tokens with the information of the API, to migrate tokens from the old contract.
`setNextMintID `allows to create a new starting point for tokens ID after the migration.
Both functions can be removed after migration.
`createNFTAuction` was changed in order to be able to add an amount of already sold tokens, because after migration some token are still on sale, so we need this info in the new contract.

To be able to use `migrationMint` first the wallet from the script should be added as minter.

**Comments on BidOfNFT**
This is probably the biggest change of this PR
The bid is stored in _bid variable in the scope of the function so we can manipulate the bided amount.
If someone bids after the end of the round and there are still rounds after, the bided amount is given back to the bidder less the minimum price of the next round, and the bidder bids for the next round the minimum amount, this is for preventing someone to bid a huge amount in the first bid of the new round. After that, a new round begins, with a delay of 10 minutes to prevent multiple bids from the previous round being added to the new round by accident.
The front end should work like this:
If the startTime + duration of the auction is higher that actual time and there are more rounds to come the front end displays a button saying "begin round" or "bid {minimum amount}".
If the startTime + duration of the auction is higher that actual time and there are more rounds to come the front end displays a button saying "claim NFT" only for the winner.

**Other things**
-Added `bytes calldata _data` to setPrice function because checkTrade needs to send a calldata type variable.
-Removed `bytes calldata _empty` cause calldata types can only be declared in external function (not sure). Without doing this a was not able to compile the contract.

> calldata - special data location that contains function arguments, only available for external functions

- setRevenueAddress is a function to change the revenue address if necessary.
- default winner wallet on auction is owner, so if no ones bids, the tokens goes to the owner to be sold in the second hand market.

-withdrawRevenue the revenue counter was not reset to 0 after withdraw.

**Test contracts:**
https://testnet-explorer.callisto.network/tokens/0xA10d69c144896f29071b6ca05F09f17A306Be078/token-transfers

https://testnet-explorer.callisto.network/address/0xdD48bdFC7A2D572E39B0DCD58313505deF6D8106/write-contract